### PR TITLE
fix: 제재 시 신고내역에 포함된 게시글도 블러처리하도록 구현

### DIFF
--- a/src/main/java/eureca/capstone/project/admin/common/entity/StatusConst.java
+++ b/src/main/java/eureca/capstone/project/admin/common/entity/StatusConst.java
@@ -4,6 +4,7 @@ public final class StatusConst {
 
     public static final String REPORT = "REPORT";
     public static final String RESTRICTION = "RESTRICTION";
+    public static final String FEED = "FEED";
 
     private StatusConst() {
     }

--- a/src/main/java/eureca/capstone/project/admin/report/service/impl/ReportServiceImpl.java
+++ b/src/main/java/eureca/capstone/project/admin/report/service/impl/ReportServiceImpl.java
@@ -315,6 +315,16 @@ public class ReportServiceImpl implements ReportService {
         relatedReports.forEach(report -> report.updateStatus(reportCompletedStatus));
         reportHistoryRepository.saveAll(relatedReports);
         log.info("[acceptRestrictions] 연관된 신고 내역 {}건의 상태를 '제재 완료'로 변경했습니다.", relatedReports.size());
+
+        // 제재와 연관된 게시글의 상태를 BLURRED로 변경
+        Status blurredStatus = statusManager.getStatus(FEED, "BLURRED");
+        List<TransactionFeed> transactionFeedsToBlur = relatedReports.stream()
+                .map(ReportHistory::getTransactionFeed)
+                .distinct() // 중복 게시글 제거
+                .toList();
+        transactionFeedsToBlur.forEach(feed -> feed.updateStatus(blurredStatus));
+        transactionFeedRepository.saveAll(transactionFeedsToBlur);
+        log.info("[acceptRestrictions] 연관된 게시글 {}건의 상태를 'BLURRED'로 변경했습니다.", transactionFeedsToBlur.size());
     }
 
     @Transactional

--- a/src/main/java/eureca/capstone/project/admin/transaction_feed/entity/TransactionFeed.java
+++ b/src/main/java/eureca/capstone/project/admin/transaction_feed/entity/TransactionFeed.java
@@ -61,4 +61,8 @@ public class TransactionFeed extends BaseEntity {
 
     @Column(name = "is_deleted")
     private boolean isDeleted;
+
+    public void updateStatus(Status status) {
+        this.status = status;
+    }
 }


### PR DESCRIPTION
### 주요 변경사항
> 제재시 신고내역과 관련된 게시글 블러처리